### PR TITLE
chore: Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "nellymoser-rs"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["relrelb <relrelbachar@gmail.com>"]
 edition = "2018"
 description = "Nellymoser decoding library written in Rust"
 license = "MIT"
 
 [dependencies]
-bitstream-io = "1.0.0"
-rustdct = "0.6.0"
+bitstream-io = "1.3.0"
+rustdct = "0.7.0"


### PR DESCRIPTION
Bump rustdct and bitstream-io dependencies, and bump crate version to 0.1.1.