### PR TITLE
Use a single global DctPlanner instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ license = "MIT"
 
 [dependencies]
 bitstream-io = "1.3.0"
+once_cell = "1.10.0"
 rustdct = "0.7.0"


### PR DESCRIPTION
The rustdct docs suggest reusing a single DctPlanner instance:
https://docs.rs/rustdct/latest/rustdct/struct.DctPlanner.html

This allows us to remove the unsafe `Send` impl and also allows
`Decoder` to be `Sync`.