### PR TITLE
chore: Bump dependencies, most notably `bitstream-io` to major version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ description = "A pure Rust decoder for the Nellymoser audio codec"
 license = "MIT"
 
 [dependencies]
-bitstream-io = "1.3.0"
-once_cell = "1.10.0"
-rustdct = "0.7.0"
+bitstream-io = "2.2.0"
+once_cell = "1.19.0"
+rustdct = "0.7.1"


### PR DESCRIPTION
I'm not sure that, with this being a library crate, bumping all minor and patch versions to the latest makes any sense (or even whether it's undesirable), but the `bitstream-io` patch would be welcome for Ruffle to deduplicate this indirect dependency.