### PR TITLE
Update bitstream-io to version 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ description = "A pure Rust decoder for the Nellymoser audio codec"
 license = "MIT"
 
 [dependencies]
-bitstream-io = "2"
+bitstream-io = "3"
 once_cell = "1.10.0"
 rustdct = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,11 @@ impl<R: Read> Decoder<R> {
         let mut pows = [0f32; NELLY_BUF_LEN];
         {
             let mut reader = BitReader::endian(Cursor::new(&block), LittleEndian);
-            let mut val = NELLY_INIT_TABLE[reader.read::<u8>(6).unwrap() as usize] as f32;
+            let mut val = NELLY_INIT_TABLE[reader.read::<6, u8>().unwrap() as usize] as f32;
             let mut ptr: usize = 0;
             for (i, x) in NELLY_BAND_SIZES_TABLE.iter().enumerate() {
                 if i > 0 {
-                    val += NELLY_DELTA_TABLE[reader.read::<u8>(5).unwrap() as usize] as f32;
+                    val += NELLY_DELTA_TABLE[reader.read::<5, u8>().unwrap() as usize] as f32;
                 }
 
                 let pval = (val / 2048.0).exp2();
@@ -212,7 +212,7 @@ impl<R: Read> Decoder<R> {
             } else if bits[j] <= 0 {
                 std::f32::consts::FRAC_1_SQRT_2
             } else {
-                let v = reader.read::<u8>(bits[j] as u32).unwrap();
+                let v = reader.read_var::<u8>(bits[j] as u32).unwrap();
                 NELLY_DEQUANTIZATION_TABLE[((1 << bits[j]) - 1 + v) as usize] as f32
             } * pows[j]).collect();
 


### PR DESCRIPTION
I hope the trivial/intuitive changes are the correct ones to follow the API changes.
Referencing: https://github.com/ruffle-rs/ruffle/pull/20044