### PR TITLE
Replace the deprecated `actions-rs` actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,23 +22,13 @@ jobs:
           components: rustfmt, clippy
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+        run: cargo fmt --check
 
       - name: Check clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --tests -- -D warnings
+        run: cargo clippy --tests -- -D warnings
 
       - name: Check build
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,11 +14,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Check formatting


### PR DESCRIPTION
We're getting ```The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.``` [annotations](https://github.com/ruffle-rs/nellymoser/actions/runs/14398823413/job/40379783947#step:3:48) because of one of them, and the repos[^1][^2] have been archived too.

[^1]: https://github.com/actions-rs/cargo
[^2]: https://github.com/actions-rs/toolchain
